### PR TITLE
Make 'MOSH Info' and 'SSH Info' dialogs more convenient

### DIFF
--- a/FluentTerminal.App/Dialogs/MoshInfoDialog.xaml
+++ b/FluentTerminal.App/Dialogs/MoshInfoDialog.xaml
@@ -8,13 +8,14 @@
     mc:Ignorable="d"
     Title="MOSH Info"
     PrimaryButtonText="OK"
-    SecondaryButtonText="Cancel">
+    SecondaryButtonText="Cancel"
+    Loaded="MoshInfoDialog_Loaded">
     <ContentDialog.DataContext>
         <viewModels:MoshConnectionInfoViewModel />
     </ContentDialog.DataContext>
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition/>
+            <ColumnDefinition Width="133"/>
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
@@ -24,21 +25,23 @@
         </Grid.RowDefinitions>
         <StackPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Center" Orientation="Horizontal">
             <TextBox
-                Width="50"
+                Width="100"
                 PlaceholderText="user"
                 Text="{Binding Username, Mode=TwoWay}" />
             <TextBlock
                 Width="20"
                 FontSize="22"
-                Text="@" />
+                Text="@"
+                TextAlignment="Center" />
             <TextBox
-                Width="120"
+                Width="160"
                 PlaceholderText="host"
                 Text="{Binding Host, Mode=TwoWay}" />
             <TextBlock
                 Width="20"
                 FontSize="22"
-                Text=":" />
+                Text=":"
+                TextAlignment="Center" />
             <TextBox
                 Width="50"
                 PlaceholderText="port"

--- a/FluentTerminal.App/Dialogs/MoshInfoDialog.xaml.cs
+++ b/FluentTerminal.App/Dialogs/MoshInfoDialog.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Windows.Foundation.Metadata;
 using Windows.UI.Xaml.Controls;
 using FluentTerminal.App.Services;
 using FluentTerminal.App.Services.Dialogs;
@@ -24,6 +25,14 @@ namespace FluentTerminal.App.Dialogs
             ContentDialogResult result = await ShowAsync();
 
             return result == ContentDialogResult.Primary ? (IMoshConnectionInfo)DataContext : null;
+        }
+
+        private void MoshInfoDialog_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            if (ApiInformation.IsPropertyPresent("Windows.UI.Xaml.Controls.ContentDialog", "DefaultButton"))
+            {
+                this.DefaultButton = ContentDialogButton.Primary;
+            }
         }
     }
 }

--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
@@ -8,27 +8,30 @@
     Title="SSH Info"
     PrimaryButtonText="OK"
     SecondaryButtonText="Cancel"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Loaded="SshInfoDialog_Loaded">
     <ContentDialog.DataContext>
         <vm:SshConnectionInfoViewModel />
     </ContentDialog.DataContext>
     <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
         <TextBox
-            Width="50"
+            Width="100"
             PlaceholderText="user"
             Text="{Binding Username, Mode=TwoWay}" />
         <TextBlock
             Width="20"
             FontSize="22"
-            Text="@" />
+            Text="@" 
+            TextAlignment="Center" />
         <TextBox
-            Width="120"
+            Width="160"
             PlaceholderText="host"
             Text="{Binding Host, Mode=TwoWay}" />
         <TextBlock
             Width="20"
             FontSize="22"
-            Text=":" />
+            Text=":" 
+            TextAlignment="Center" />
         <TextBox
             Width="50"
             PlaceholderText="port"

--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml.cs
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Windows.Foundation.Metadata;
 using Windows.UI.Xaml.Controls;
 using FluentTerminal.App.Services.Dialogs;
 using FluentTerminal.App.Utilities;
@@ -21,6 +22,14 @@ namespace FluentTerminal.App.Dialogs
             ContentDialogResult result = await ShowAsync();
 
             return result == ContentDialogResult.Primary ? (ISshConnectionInfo)DataContext : null;
+        }
+
+        private void SshInfoDialog_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            if (ApiInformation.IsPropertyPresent("Windows.UI.Xaml.Controls.ContentDialog", "DefaultButton"))
+            {
+                this.DefaultButton = ContentDialogButton.Primary;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR makes text fields on the `MOSH Info` and `SSH Info` dialogs more wider which is more convenient when entering long user names and host addresses.

Also, this PR declares the "OK" button as default so pressing Enter key is equal to clicking on the "OK" button.