### PR TITLE
Clean up SSH/Mosh UI code

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -121,19 +121,6 @@ namespace FluentTerminal.App.Services.Implementation
                         }
                     };
 
-                case Command.NewMoshTab:
-                    return new List<KeyBinding>
-                    {
-                        new KeyBinding
-                        {
-                            Command = nameof(Command.NewMoshTab),
-                            Ctrl = false,
-                            Alt = true,
-                            Shift = false,
-                            Key = (int)ExtendedVirtualKey.Y
-                        }
-                    };
-
                 case Command.ChangeTabTitle:
                     return new List<KeyBinding>
                 {

--- a/FluentTerminal.App.ViewModels/RemoteHostType.cs
+++ b/FluentTerminal.App.ViewModels/RemoteHostType.cs
@@ -1,9 +1,0 @@
-﻿
-namespace FluentTerminal.App.ViewModels
-{
-    public enum RemoteHostType
-    {
-        Ssh, 
-        Mosh
-    }
-}

--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
@@ -55,7 +55,7 @@
                 Click="BrowseButtonOnClick" />
         <CheckBox Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="5"
                   IsChecked="{Binding UseMosh, Mode=TwoWay}"
-                  Content="Use MOSH"
+                  Content="Use Mosh"
                   Margin="0 10 0 0" />
     </Grid>
 </ContentDialog>

--- a/FluentTerminal.Models/Enums/Command.cs
+++ b/FluentTerminal.Models/Enums/Command.cs
@@ -22,9 +22,6 @@ namespace FluentTerminal.Models.Enums
         [Description("New SSH tab")]
         NewSshTab,
 
-        [Description("New MOSH tab")]
-        NewMoshTab,
-
         [Description("Change tab title")]
         ChangeTabTitle,
 


### PR DESCRIPTION
The code around the SSH dialog has been cleaned up now that one dialog will handle both SSH and Mosh connections.

Also, the "MOSH" field label is now "Mosh" (as per how the Mosh project writes it).