### PR TITLE
App activation on mosh schema launching; mosh protocol parsing.

### DIFF
--- a/FluentTerminal.App.ViewModels/SshConnectionInfoViewModel.cs
+++ b/FluentTerminal.App.ViewModels/SshConnectionInfoViewModel.cs
@@ -52,5 +52,8 @@ namespace FluentTerminal.App.ViewModels
             get => _moshPorts;
             set => Set(ref _moshPorts, value);
         }
+
+        public string FirstMoshPort { get; set; }
+        public string LastMoshPort { get; set; }
     }
 }

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -163,6 +163,14 @@ namespace FluentTerminal.App
 #pragma warning disable 4014
                         CreateTerminal(profile, NewTerminalLocation.Tab);
 #pragma warning restore 4014
+                } else if (MoshProtocolHandler.IsMoshProtocol(protocolActivated))
+                {
+                    var profile = MoshProtocolHandler.GetSshShellProfile(protocolActivated);
+
+                    if (profile != null)
+#pragma warning disable 4014
+                        CreateTerminal(profile, NewTerminalLocation.Tab);
+#pragma warning restore 4014
                 }
 
                 return;

--- a/FluentTerminal.App/FluentTerminal.App.csproj
+++ b/FluentTerminal.App/FluentTerminal.App.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Dialogs\ShellProfileSelectionDialog.xaml.cs">
       <DependentUpon>ShellProfileSelectionDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Protocols\MoshProtocolHandler.cs" />
     <Compile Include="Protocols\SshProtocolHandler.cs" />
     <Compile Include="Services\ClipboardService.cs" />
     <Compile Include="Services\FileSystemService.cs" />

--- a/FluentTerminal.App/Package.appxmanifest
+++ b/FluentTerminal.App/Package.appxmanifest
@@ -47,6 +47,11 @@
             <uap:DisplayName>SSH Session</uap:DisplayName>
           </uap:Protocol>
         </uap:Extension>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="mosh">
+            <uap:DisplayName>Mobile Shell Session</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/FluentTerminal.App/Protocols/MoshProtocolHandler.cs
+++ b/FluentTerminal.App/Protocols/MoshProtocolHandler.cs
@@ -1,0 +1,59 @@
+﻿using System.Text.RegularExpressions;
+using Windows.ApplicationModel.Activation;
+using FluentTerminal.App.Services;
+using FluentTerminal.App.Services.Dialogs;
+using FluentTerminal.App.ViewModels;
+using FluentTerminal.Models;
+using FluentTerminal.Models.Enums;
+
+namespace FluentTerminal.App.Protocols
+{
+    internal static class MoshProtocolHandler
+    {
+        private const ushort DefaultSshPort = 22;
+
+        private const string MoshProtocol = "mosh";
+
+        private static readonly Regex MoshUrlRx =
+            new Regex(
+                @"^\s*mosh://(?<user>[^;@]+)(;fingerprint=(?<fingerprint>[^@]+))?@(?<host>[^/:\s]+)(:(?<port>\d{1,5}))?/?\?(mosh-ports=(?<moshports>(?<firstport>\d{1,5})-(?<lastport>\d{1,5})))?\s*$",
+                RegexOptions.Compiled);
+
+        internal static bool IsMoshProtocol(ProtocolActivatedEventArgs protocolEventArgs) =>
+            protocolEventArgs.Uri.Scheme.ToLowerInvariant().Equals(MoshProtocol);
+
+        internal static ISshConnectionInfo GetMoshConnectionInfo(ProtocolActivatedEventArgs protocolEventArgs)
+        {
+            Match match = MoshUrlRx.Match(protocolEventArgs.Uri.AbsoluteUri);
+
+            return match.Success
+                ? new SshConnectionInfoViewModel
+                {
+                    Host = match.Groups["host"].Value,
+                    SshPort = match.Groups["port"].Success ? ushort.Parse(match.Groups["port"].Value) : DefaultSshPort,
+                    Username = match.Groups["user"].Value,
+                    UseMosh = true,
+                    MoshPorts = match.Groups["moshports"].Success ? match.Groups["moshports"].Value : "60000-60050",
+                    FirstMoshPort = match.Groups["firstport"].Success ? match.Groups["firstport"].Value : "60000",
+                    LastMoshPort = match.Groups["lastport"].Success ? match.Groups["lastport"].Value : "60050"
+                }
+                : null;
+        }
+
+        internal static ShellProfile GetSshShellProfile(ProtocolActivatedEventArgs protocolEventArgs)
+        {
+            Match match = MoshUrlRx.Match(protocolEventArgs.Uri.AbsoluteUri);
+
+            return match.Success
+                ? new ShellProfile
+                {
+                    Arguments =
+                        $"-p {(match.Groups["port"].Success ? ushort.Parse(match.Groups["port"].Value) : DefaultSshPort):#####} {match.Groups["user"].Value}@{match.Groups["host"].Value}",
+                    Location = @"C:\Windows\System32\OpenSSH\ssh.exe",
+                    WorkingDirectory = string.Empty,
+                    LineEndingTranslation = LineEndingStyle.DoNotModify
+                }
+                : null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #32 

- Application activation on visiting url with `mosh` schema
- MoshProtocolHandler to parse `mosh` protocol schema of `mosh://user@host:sshport?mosh-ports=firstport-lastport` format.
- ssh.exe temporary launched instead of mosh.exe