### PR TITLE
Trivial Mosh checkbox label fix

### DIFF
--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
@@ -55,7 +55,7 @@
                 Click="BrowseButtonOnClick" />
         <CheckBox Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="5"
                   IsChecked="{Binding UseMosh, Mode=TwoWay}"
-                  Content="Use MOSH"
+                  Content="Use Mosh"
                   Margin="0 10 0 0" />
     </Grid>
 </ContentDialog>


### PR DESCRIPTION
It's "Mosh" not "MOSH".