### PR TITLE
Make SSH user optional

### DIFF
--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -10,6 +10,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentTerminal.App.ViewModels.Utilities;
+using System.Text;
 
 namespace FluentTerminal.App.ViewModels
 {
@@ -239,16 +240,22 @@ namespace FluentTerminal.App.ViewModels
                 return;
             }
 
-            string arguments = sshConnectionInfo.SshPort == 22 ? "" : $"-p {sshConnectionInfo.SshPort:#####} ";
-
-            if (!string.IsNullOrEmpty(sshConnectionInfo.IdentityFile))
-                arguments += $"-i {sshConnectionInfo.IdentityFile} ";
-
-            arguments += $"{sshConnectionInfo.Username}@{sshConnectionInfo.Host}";
+            StringBuilder arguments = new StringBuilder();
+            if (sshConnectionInfo.SshPort != 22)
+            {
+                arguments.Append($"-p {sshConnectionInfo.SshPort:#####} ");
+            }
+            if (!string.IsNullOrEmpty(sshConnectionInfo.IdentityFile)) { 
+                arguments.Append($"-i {sshConnectionInfo.IdentityFile} ");
+            }
+            if (!string.IsNullOrEmpty(sshConnectionInfo.Username)) {
+                arguments.Append($"{sshConnectionInfo.Username}@");
+            }
+            arguments.Append(sshConnectionInfo.Host);
 
             ShellProfile profile = new ShellProfile
             {
-                Arguments = arguments,
+                Arguments = arguments.ToString(),
                 Location = Helpers.SshExeLocation,
                 WorkingDirectory = string.Empty,
                 LineEndingTranslation = LineEndingStyle.DoNotModify,

--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml.cs
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml.cs
@@ -39,25 +39,21 @@ namespace FluentTerminal.App.Dialogs
         {
             SshConnectionInfoViewModel vm = (SshConnectionInfoViewModel)DataContext;
 
-            if (string.IsNullOrEmpty(vm.Username) || string.IsNullOrEmpty(vm.Host))
+            if (string.IsNullOrEmpty(vm.Host))
             {
-                args.Cancel = true;
-
-                MessageDialog d = new MessageDialog("User and host are mandatory fields.", "Invalid Form");
-
+                MessageDialog d = new MessageDialog("Please provide a host to connect to.", "Invalid");
                 await d.ShowAsync();
 
+                args.Cancel = true;
                 return;
             }
 
             if (vm.SshPort == 0)
             {
-                args.Cancel = true;
-
-                MessageDialog d = new MessageDialog("Port cannot be 0.", "Invalid Form");
-
+                MessageDialog d = new MessageDialog("Port cannot be 0.", "Invalid");
                 await d.ShowAsync();
 
+                args.Cancel = true;
                 return;
             }
 


### PR DESCRIPTION
It is often the case that the remote SSH username is the same as the local one (i.e. this is the case at Jump). Allow the username to be empty and adjust the code that creates the arguments to only try to pass a username if it's set.

