### PR TITLE
Run unit tests with Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ artifacts:
 build_script:
   - msbuild /maxcpucount:%NUMBER_OF_PROCESSORS% /t:Build /p:Configuration=Release /p:AppxBundle=Always /p:Platform="x64" /v:q /nologo FluentTerminal.sln
 test_script:
-  - echo Skipt tests run
+  - dotnet test ./FluentTerminal.App.Services.Test
 deploy:
   release: 'FluentTerminal-%APPVEYOR_BUILD_VERSION%-${GIT_COMMIT_SHORT}'
   description: 'Build ${APPVEYOR_REPO_COMMIT} on master branch'


### PR DESCRIPTION
Fixes #31 

Appveyor automatically grabs unit tests results and publishes to separate Tab of build job. Sample of how failed unit tests look can be found there https://ci.appveyor.com/project/MaxRisuhin/fluentterminal/builds/24100538/tests