### PR TITLE
Msi installer

### DIFF
--- a/MsiInstaller/Generate-AppxMsi.ps1
+++ b/MsiInstaller/Generate-AppxMsi.ps1
@@ -1,0 +1,24 @@
+$WixRoot = "$PSScriptRoot\wix"
+$InstallFileswsx = "..\Template.wxs"
+$InstallFilesWixobj = "..\FluentTerminalInstaller.wixobj"
+
+if(!(Test-Path "$WixRoot\candle.exe"))
+{
+    
+	Write-Host Downloading Wixtools..
+    New-Item $WixRoot -type directory -force | Out-Null
+    # Download Wix version 3.11.1 - https://github.com/wixtoolset/wix3/releases/tag/wix3111rtm
+    Invoke-WebRequest -Uri https://github.com/wixtoolset/wix3/releases/download/wix3111rtm/wix311-binaries.zip -Method Get -OutFile $WixRoot\WixTools.zip
+
+    Write-Host Extracting Wixtools..
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory("$WixRoot\WixTools.zip", $WixRoot)
+}
+
+pushd "$WixRoot"
+.\candle.exe $InstallFileswsx -ext WixUtilExtension -o "$PSScriptRoot\FluentTerminalInstaller.wixobj" 
+.\light.exe $InstallFilesWixobj -ext WixUtilExtension -b "$PSScriptRoot" -o "$PSScriptRoot\FluentTerminalInstaller.msi" 
+popd
+
+#msiexec.exe /i FluentTerminalInstaller.msi /log log.txt
+#msiexec.exe /x FluentTerminalInstaller.msi /log log.txt

--- a/MsiInstaller/Install-UntrustedAppx.ps1
+++ b/MsiInstaller/Install-UntrustedAppx.ps1
@@ -1,0 +1,60 @@
+﻿param(
+    [string]$packageName = $null,
+    [switch]$InstallCert,
+    [switch]$EnableSideLoad
+)
+
+if($InstallCert -or $EnableSideLoad){
+    if($InstallCert){
+        certutil.exe -addstore TrustedPeople "$PSScriptRoot\$packageName.cer"
+    }
+
+    if($EnableSideLoad){
+        set-itemproperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock -Name AllowAllTrustedApps -Value 1 -Verbose
+    }
+    exit 0
+}
+else{
+    $PackageSignature = Get-AuthenticodeSignature "$PSScriptRoot\$packageName.appxbundle"
+    $PackageCertificate = $PackageSignature.SignerCertificate
+
+    if (!$PackageCertificate)
+    {
+    	throw "Usigned package"
+    	exit -1
+    }
+
+    $enableSideLoad = (test-path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock) -and ((get-item HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock).Property.Count -ne 0)
+
+    if($enableSideLoad){
+        $enableSideLoad = (get-itemproperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock -Name AllowAllTrustedApps).AllowAllTrustedApps -ne 1
+    }
+
+    $trustCert = $PackageSignature.Status -ne "Valid"
+
+    if ($enableSideLoad -or $trustCert)
+    {
+        $RelaunchArgs = '-ExecutionPolicy Bypass -file "' + "$PSScriptRoot\Install-UntrustedAppx.ps1" + '"' + " $packageName"
+    
+        if($trustCert){
+            $RelaunchArgs += " -InstallCert"
+        }
+
+        if($enableSideLoad){
+            $RelaunchArgs += " -EnableSideLoad"
+        }
+
+        $AdminProcess = Start-Process "powershell.exe" -Verb RunAs -WorkingDirectory $PSScriptRoot -ArgumentList $RelaunchArgs -Wait
+    }
+
+    $DependencyPackages = Get-ChildItem (Join-Path (Join-Path $PSScriptRoot "Dependencies") "*.appx")
+    
+    if ($DependencyPackages.Count -gt 0)
+    {
+    	Add-AppxPackage -Path "$PSScriptRoot\$packageName.appxbundle" -DependencyPath $DependencyPackages.FullName -ForceApplicationShutdown -Verbose
+    }
+    else
+    {
+    	Add-AppxPackage -Path "$PSScriptRoot\$packageName.appxbundle" -ForceApplicationShutdown -Verbose
+    }
+}

--- a/MsiInstaller/Template.wxs
+++ b/MsiInstaller/Template.wxs
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" UpgradeCode="7b0af2d8-d27b-4a07-9be5-88185a9153be"
+           Name="Fluent Terminal Installer" Version="0.0.1" Manufacturer="Example Company Name" Language="1033">
+    <Package InstallerVersion="200" Compressed="yes" Comments="Windows Installer Package" Platform="x64"/>
+    <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
+
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLDIR" Name="Fluent Terminal Installer">
+          <Component Id="ApplicationFiles" Guid="a2a84f6a-2654-4ace-aefd-55387c5cb015">
+            <File Id="InstallUntrustedAppx.ps1" Source="Install-UntrustedAppx.ps1"/>
+            <File Id="UninstallUntrustedAppx.ps1" Source="Uninstall-UntrustedAppx.ps1"/>
+            <File Id="FluentTerminal.App.appxbundle" Source="FluentTerminal.App.appxbundle"/>
+            <File Id="FluentTerminal.App.cer" Source="FluentTerminal.App.cer"/>
+          </Component>
+          <Directory Id="DependencyDir" Name="Dependencies">
+            <Component Id="DependencyFiles" Guid="2b6515e9-5b3a-4789-b1f0-cb44d29ab987">
+              <File Id="Microsoft.NET.Native.Framework.2.2.appx" Source="Dependencies/x64/Microsoft.NET.Native.Framework.2.2.appx"/>
+              <File Id="Microsoft.NET.Native.Runtime.2.2.appx" Source="Dependencies/x64/Microsoft.NET.Native.Runtime.2.2.appx"/>
+              <File Id="Microsoft.VCLibs.x64.14.00.appx" Source="Dependencies/x64/Microsoft.VCLibs.x64.14.00.appx"/>
+            </Component>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <Feature Id="DefaultFeature" Level="1">
+      <ComponentRef Id="ApplicationFiles"/>
+      <ComponentRef Id="DependencyFiles"/>
+    </Feature>
+
+    <SetProperty Id="InstallAppx" Before="InstallFiles" Sequence="execute" Value ="&quot;C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -File &quot;[INSTALLDIR]Install-UntrustedAppx.ps1&quot; FluentTerminal.App" />
+    <CustomAction Id="InstallAppx" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="yes" />
+
+    <SetProperty Id="UninstallAppx" Before="InstallFiles" Sequence="execute" Value ="&quot;powershell.exe&quot; -ExecutionPolicy Bypass -File &quot;[INSTALLDIR]Uninstall-UntrustedAppx.ps1&quot; FluentTerminal.App" />
+    <CustomAction Id="UninstallAppx" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="yes" />
+
+    <InstallExecuteSequence>
+      <Custom Action='InstallAppx' After='InstallFiles'>NOT REMOVE</Custom>
+      <Custom Action='UninstallAppx' After='InstallFiles'>REMOVE~=ALL</Custom>
+    </InstallExecuteSequence>
+
+  </Product>
+</Wix>

--- a/MsiInstaller/Uninstall-UntrustedAppx.ps1
+++ b/MsiInstaller/Uninstall-UntrustedAppx.ps1
@@ -1,0 +1,6 @@
+﻿param(
+    [string]$packageName = $null
+)
+
+
+#Remove-AppxPackage $packageName

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ before_build:
     $manifest.Save((Resolve-Path './FluentTerminal.App/Package.appxmanifest'))
 - cmd: pushd . && cd FluentTerminal.Client && npm install && npm run-script build && popd && nuget restore FluentTerminal.sln
 after_build:
+- cmd: '7z a FluentTerminal-v%APPVEYOR_BUILD_VERSION%-%GIT_COMMIT_SHORT%.zip FluentTerminal.App\AppPackages\*'
 - cmd: >-
-    '7z a FluentTerminal-v%APPVEYOR_BUILD_VERSION%-%GIT_COMMIT_SHORT%.zip FluentTerminal.App\AppPackages\*'
      pushd FluentTerminal.App\AppPackages\FluentTerminal*\Dependencies && dir && xcopy * "../../../../MsiInstaller/Dependencies" /e/i/f && popd
      pushd FluentTerminal.App\AppPackages\FluentTerminal*\ && dir && xcopy "*.appxbundle" "../../../MsiInstaller/" /e/i/f && popd && ren MsiInstaller\*.appxbundle FluentTerminal.App.appxbundle
      pushd FluentTerminal.App\AppPackages\FluentTerminal*\ && dir && xcopy "*.cer" "../../../MsiInstaller/" /e/i/f && popd && ren MsiInstaller\*.cer FluentTerminal.App.cer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,17 @@ before_build:
     $manifest.Save((Resolve-Path './FluentTerminal.App/Package.appxmanifest'))
 - cmd: pushd . && cd FluentTerminal.Client && npm install && npm run-script build && popd && nuget restore FluentTerminal.sln
 after_build:
-- cmd: '7z a FluentTerminal-v%APPVEYOR_BUILD_VERSION%-%GIT_COMMIT_SHORT%.zip FluentTerminal.App\AppPackages\*'
+- cmd: >-
+    '7z a FluentTerminal-v%APPVEYOR_BUILD_VERSION%-%GIT_COMMIT_SHORT%.zip FluentTerminal.App\AppPackages\*'
+     pushd FluentTerminal.App\AppPackages\FluentTerminal*\Dependencies && dir && xcopy * "../../../../MsiInstaller/Dependencies" /e/i/f && popd
+     pushd FluentTerminal.App\AppPackages\FluentTerminal*\ && dir && xcopy "*.appxbundle" "../../../MsiInstaller/" /e/i/f && popd && ren MsiInstaller\*.appxbundle FluentTerminal.App.appxbundle
+     pushd FluentTerminal.App\AppPackages\FluentTerminal*\ && dir && xcopy "*.cer" "../../../MsiInstaller/" /e/i/f && popd && ren MsiInstaller\*.cer FluentTerminal.App.cer
+     pushd MsiInstaller && powershell.exe -ExecutionPolicy Bypass  -file ".\Generate-AppxMsi.ps1" && popd
 artifacts:
   - path: 'FluentTerminal-v%APPVEYOR_BUILD_VERSION%-${GIT_COMMIT_SHORT}.zip'
     name: AppPackage
+  - path: 'MsiInstaller/FluentTerminalInstaller.msi'
+    name: MsiInstaller
 build_script:
   - msbuild /maxcpucount:%NUMBER_OF_PROCESSORS% /t:Build /p:Configuration=Release /p:AppxBundle=Always /p:Platform="x64" /v:q /nologo FluentTerminal.sln
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,10 @@ before_build:
 - cmd: pushd . && cd FluentTerminal.Client && npm install && npm run-script build && popd && nuget restore FluentTerminal.sln
 after_build:
 - cmd: '7z a FluentTerminal-v%APPVEYOR_BUILD_VERSION%-%GIT_COMMIT_SHORT%.zip FluentTerminal.App\AppPackages\*'
-- cmd: >-
-     pushd FluentTerminal.App\AppPackages\FluentTerminal*\Dependencies && dir && xcopy * "../../../../MsiInstaller/Dependencies" /e/i/f && popd
-     pushd FluentTerminal.App\AppPackages\FluentTerminal*\ && dir && xcopy "*.appxbundle" "../../../MsiInstaller/" /e/i/f && popd && ren MsiInstaller\*.appxbundle FluentTerminal.App.appxbundle
-     pushd FluentTerminal.App\AppPackages\FluentTerminal*\ && dir && xcopy "*.cer" "../../../MsiInstaller/" /e/i/f && popd && ren MsiInstaller\*.cer FluentTerminal.App.cer
-     pushd MsiInstaller && powershell.exe -ExecutionPolicy Bypass  -file ".\Generate-AppxMsi.ps1" && popd
+- cmd: pushd FluentTerminal.App\AppPackages\FluentTerminal*\Dependencies && dir && xcopy * "../../../../MsiInstaller/Dependencies" /e/i/f && popd
+- cmd: pushd FluentTerminal.App\AppPackages\FluentTerminal*\ && dir && xcopy "*.appxbundle" "../../../MsiInstaller/" /e/i/f && popd && ren MsiInstaller\*.appxbundle FluentTerminal.App.appxbundle
+- cmd: pushd FluentTerminal.App\AppPackages\FluentTerminal*\ && dir && xcopy "*.cer" "../../../MsiInstaller/" /e/i/f && popd && ren MsiInstaller\*.cer FluentTerminal.App.cer
+- cmd: pushd MsiInstaller && powershell.exe -ExecutionPolicy Bypass  -file ".\Generate-AppxMsi.ps1" && popd
 artifacts:
   - path: 'FluentTerminal-v%APPVEYOR_BUILD_VERSION%-${GIT_COMMIT_SHORT}.zip'
     name: AppPackage


### PR DESCRIPTION
Fixes #42 

Builds msi installer and publishes it to GitHub Releases as `master` branch build artifact.

Solution adopted from https://github.com/aL3891/AppxInstaller

Installer does:
- Copies appx related files into `C:/Program Files(x86)/Fluent Terminal Installer` directory
- Turns on appx sideloading support in Windows Registry on target user's machine
- Installs developer certificate
- Runs powershell.exe's `Add-AppxPackage` to install application's appxbundle and dependencies