### PR TITLE
Set line endings for remote shell connection & fix form validation 

### DIFF
--- a/FluentTerminal.App.ViewModels/SshConnectionInfoViewModel.cs
+++ b/FluentTerminal.App.ViewModels/SshConnectionInfoViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using FluentTerminal.App.Services;
 using GalaSoft.MvvmLight;
+using FluentTerminal.Models.Enums;
 
 namespace FluentTerminal.App.ViewModels
 {
@@ -64,6 +65,37 @@ namespace FluentTerminal.App.ViewModels
         {
             get => _moshPortTo;
             set => Set(ref _moshPortTo, value);
+        }
+
+        private LineEndingStyle _lineEndingStyle = LineEndingStyle.ToLF;
+        public LineEndingStyle LineEndingStyle
+        {
+            get => _lineEndingStyle;
+            set => Set(ref _lineEndingStyle, value);
+        }
+
+        public bool DoNotModifyIsSelected
+        {
+            get => LineEndingStyle == LineEndingStyle.DoNotModify;
+            set { if (value) LineEndingStyle = LineEndingStyle.DoNotModify; }
+        }
+
+        public bool ToCRLFIsSelected
+        {
+            get => LineEndingStyle == LineEndingStyle.ToCRLF;
+            set { if (value) LineEndingStyle = LineEndingStyle.ToCRLF; }
+        }
+
+        public bool ToLFIsSelected
+        {
+            get => LineEndingStyle == LineEndingStyle.ToLF;
+            set { if (value) LineEndingStyle = LineEndingStyle.ToLF; }
+        }
+
+        public bool ToCRIsSelected
+        {
+            get => LineEndingStyle == LineEndingStyle.ToCR;
+            set { if (value) LineEndingStyle = LineEndingStyle.ToCR; }
         }
 
         public ObservableCollection<SshOptionViewModel> SshOptions { get; } =

--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
@@ -30,7 +30,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
-        <TextBox Grid.Column="0" Grid.Row="0"
+        <TextBox x:Name="userTextBox" Grid.Column="0" Grid.Row="0"
                  PlaceholderText="user"
                  Text="{Binding Username, Mode=TwoWay}" />
         <TextBlock Grid.Column="1" Grid.Row="0"
@@ -38,7 +38,7 @@
                    Text="@" />
         <TextBox x:Name="hostTextBox"  Grid.Column="2" Grid.Row="0"
                  PlaceholderText="host"
-                 Text="{Binding Host, Mode=TwoWay}"/>
+                 Text="{Binding Host, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
         <TextBlock Grid.Column="3" Grid.Row="0"
                    Margin="2 0 0 0"
                    FontSize="22"
@@ -82,7 +82,7 @@
                 <ListBox Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" 
                          HorizontalAlignment="Stretch"
                          Margin="0 10 0 0"
-                         Height="200"/>
+                         Height="100"/>
                 <Grid Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2" 
                       Margin="0 10 0 0"
                       Visibility="{Binding UseMosh}">
@@ -104,6 +104,25 @@
                              BeforeTextChanging="Port_OnBeforeTextChanging"/>
                 </Grid>
                 <TextBlock Grid.Column="0" Grid.Row="3" Text=" " />
+                <StackPanel Grid.Row="4" Grid.ColumnSpan="4">
+                    <TextBlock Margin="0,10,0,8" Text="Select line ending translation mode on paste:" />
+                    <RadioButton
+                                        Content="Do not modify line endings"
+                                        GroupName="LineEndingStyle"
+                                        IsChecked="{Binding DoNotModifyIsSelected, Mode=TwoWay}" />
+                    <RadioButton
+                                        Content="Convert line endings to CR+LF"
+                                        GroupName="LineEndingStyle"
+                                        IsChecked="{Binding ToCRLFIsSelected, Mode=TwoWay}" />
+                    <RadioButton
+                                        Content="Convert line endings to CR"
+                                        GroupName="LineEndingStyle"
+                                        IsChecked="{Binding ToCRIsSelected, Mode=TwoWay}" />
+                    <RadioButton
+                                        Content="Convert line endings to LF"
+                                        GroupName="LineEndingStyle"
+                                        IsChecked="{Binding ToLFIsSelected, Mode=TwoWay}" />
+                </StackPanel>
             </Grid>
         </controls:Expander>
         <Grid Grid.Column="0" Grid.Row="4" Grid.ColumnSpan="5"

--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml.cs
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml.cs
@@ -37,6 +37,24 @@ URL={0}
             RequestedTheme = ContrastHelper.GetIdealThemeForBackgroundColor(currentTheme.Colors.Background);
         }
 
+        private void SetupFocus()
+        {
+            SshConnectionInfoViewModel vm = (SshConnectionInfoViewModel)DataContext;
+
+            if (string.IsNullOrEmpty(vm.Username))
+            {
+                userTextBox.Focus(FocusState.Programmatic);
+            }
+            else if (string.IsNullOrEmpty(vm.Host))
+            {
+                hostTextBox.Focus(FocusState.Programmatic);
+            }
+            else
+            {
+                Focus(FocusState.Programmatic);
+            }
+        }
+
         private async void OnLoading(FrameworkElement sender, object args)
         {
             SshConnectionInfoViewModel vm = (SshConnectionInfoViewModel)DataContext;
@@ -46,8 +64,7 @@ URL={0}
 
             vm.Username = await _trayProcessCommunicationService.GetUserName();
 
-            if (string.IsNullOrEmpty(vm.Host) && !string.IsNullOrEmpty(vm.Username))
-                hostTextBox.Focus(FocusState.Programmatic);
+            SetupFocus();
         }
 
         private async void BrowseButtonOnClick(object sender, RoutedEventArgs e)
@@ -113,6 +130,7 @@ URL={0}
 
                 await new MessageDialog("User and host are mandatory fields.", "Invalid Form").ShowAsync();
 
+                SetupFocus();
                 return;
             }
 
@@ -120,10 +138,9 @@ URL={0}
             {
                 args.Cancel = true;
 
-                MessageDialog d = new MessageDialog("Port cannot be 0.", "Invalid Form");
+                await new MessageDialog("Port cannot be 0.", "Invalid Form").ShowAsync();
 
-                await d.ShowAsync();
-
+                SetupFocus();
                 return;
             }
 
@@ -138,6 +155,7 @@ URL={0}
             if (input != null)
                 DataContext = ((SshConnectionInfoViewModel)input).Clone();
 
+            this.Focus(FocusState.Programmatic);
             return await ShowAsync() == ContentDialogResult.Primary ? (SshConnectionInfoViewModel) DataContext : null;
         }
     }

--- a/FluentTerminal.App/Services/SshHelperService.cs
+++ b/FluentTerminal.App/Services/SshHelperService.cs
@@ -188,7 +188,7 @@ namespace FluentTerminal.App.Services
                 Arguments = GetArgumentsString(sshConnectionInfo),
                 Location = sshConnectionInfo.UseMosh ? MoshExe : SshExeLocationLazy.Value,
                 WorkingDirectory = string.Empty,
-                LineEndingTranslation = LineEndingStyle.DoNotModify
+                LineEndingTranslation = sshConnectionInfo.LineEndingStyle
             };
 
         #endregion Static


### PR DESCRIPTION
Left focus on SSH info dialog if input validation error occured;
Update DataContext object on each key entered into target host text box control.

Fixes #61 and #63 