### PR TITLE
Appveyor and installer building update

### DIFF
--- a/FluentTerminal.App.Services/Implementation/UpdateService.cs
+++ b/FluentTerminal.App.Services/Implementation/UpdateService.cs
@@ -47,11 +47,8 @@ namespace FluentTerminal.App.Services.Implementation
             {
                 dynamic restResponseData = JsonConvert.DeserializeObject(restResponse.Content);
                 string tag = restResponseData[0].tag_name;
-                if (tag.Split('-').Length == 3)
-                {
-                    var latestVersion = new Version(tag.Split('-')[1]);
-                    return new Version(latestVersion.Major, latestVersion.Minor, latestVersion.Build, latestVersion.Revision);
-                }
+                var latestVersion = new Version(tag);
+                return new Version(latestVersion.Major, latestVersion.Minor, latestVersion.Build, latestVersion.Revision);
             }
             return new Version(0, 0, 0, 0);
         }

--- a/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
@@ -8,7 +8,7 @@ namespace FluentTerminal.App.ViewModels.Settings
 {
     public class AboutPageViewModel : ViewModelBase
     {
-        private const string BaseUrl = "https://github.com/felixse/FluentTerminal/releases/tag/";
+        private const string BaseUrl = "https://github.com/jumptrading/FluentTerminal/releases/tag/";
         private readonly ISettingsService _settingsService;
         private readonly IUpdateService _updateService;
         private string _latestVersion;

--- a/FluentTerminal.App/Package.appxmanifest
+++ b/FluentTerminal.App/Package.appxmanifest
@@ -4,7 +4,7 @@
   <mp:PhoneIdentity PhoneProductId="f7225014-f405-4342-ad2e-ebf6ac60ea2c" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Fluent Terminal</DisplayName>
-    <PublisherDisplayName>FS Apps</PublisherDisplayName>
+    <PublisherDisplayName>Jump Trading</PublisherDisplayName>
     <Logo>Assets\AppIcons\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>

--- a/MsiInstaller/Generate-AppxMsi.ps1
+++ b/MsiInstaller/Generate-AppxMsi.ps1
@@ -5,7 +5,7 @@ $InstallFilesWixobj = "..\FluentTerminalInstaller.wixobj"
 if(!(Test-Path "$WixRoot\candle.exe"))
 {
     
-	Write-Host Downloading Wixtools..
+    Write-Host Downloading Wixtools..
     New-Item $WixRoot -type directory -force | Out-Null
     # Download Wix version 3.11.1 - https://github.com/wixtoolset/wix3/releases/tag/wix3111rtm
     Invoke-WebRequest -Uri https://github.com/wixtoolset/wix3/releases/download/wix3111rtm/wix311-binaries.zip -Method Get -OutFile $WixRoot\WixTools.zip

--- a/MsiInstaller/Template.wxs
+++ b/MsiInstaller/Template.wxs
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" UpgradeCode="7b0af2d8-d27b-4a07-9be5-88185a9153be"
-           Name="Fluent Terminal Installer" Version="0.0.1" Manufacturer="Example Company Name" Language="1033">
+           Name="Fluent Terminal Installer" Version="0.0.1" Manufacturer="Jump Trading" Language="1033">
     <Package InstallerVersion="200" Compressed="yes" Comments="Windows Installer Package" Platform="x64"/>
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed. Please uninstall it first. Setup will now exit."/>
     <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
 
     <Directory Id="TARGETDIR" Name="SourceDir">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}.0
+version: 1.1.{build}
 pull_requests:
   do_not_increment_build_number: true
 os: Visual Studio 2017
@@ -7,29 +7,35 @@ platform:
 - x64
 skip_tags: true
 before_build:
+- cmd: set APP_BUILD_VERSION=%APPVEYOR_BUILD_VERSION%.0
 - cmd: git rev-parse --short HEAD>commit.txt && set /p GIT_COMMIT_SHORT=<commit.txt
+- cmd: set MSI_ARTIFACT_NAME=FluentTerminalInstaller-v%APP_BUILD_VERSION%-%GIT_COMMIT_SHORT%.msi
+- cmd: set APPX_ARTIFACT_NAME=FluentTerminal-v%APP_BUILD_VERSION%-%GIT_COMMIT_SHORT%.zip
 - ps: |
     [xml]$manifest = Get-Content './FluentTerminal.App/Package.appxmanifest'
-    $manifest.Package.Identity.Version = "1.0.$Env:APPVEYOR_BUILD_NUMBER.0"
+    $manifest.Package.Identity.Version = "$Env:APP_BUILD_VERSION"
     $manifest.Save((Resolve-Path './FluentTerminal.App/Package.appxmanifest'))
+    [xml]$msiTemplate = Get-Content './MsiInstaller/Template.wxs'
+    $msiTemplate.Wix.Product.Version = "$Env:APP_BUILD_VERSION"
+    $msiTemplate.Save((Resolve-Path './MsiInstaller/Template.wxs'))
 - cmd: pushd . && cd FluentTerminal.Client && npm install && npm run-script build && popd && nuget restore FluentTerminal.sln
 after_build:
-- cmd: '7z a FluentTerminal-v%APPVEYOR_BUILD_VERSION%-%GIT_COMMIT_SHORT%.zip FluentTerminal.App\AppPackages\*'
+- cmd: '7z a %APPX_ARTIFACT_NAME% FluentTerminal.App\AppPackages\*'
 - cmd: pushd FluentTerminal.App\AppPackages\FluentTerminal*\Dependencies && dir && xcopy * "../../../../MsiInstaller/Dependencies" /e/i/f && popd
 - cmd: pushd FluentTerminal.App\AppPackages\FluentTerminal*\ && dir && xcopy "*.appxbundle" "../../../MsiInstaller/" /e/i/f && popd && ren MsiInstaller\*.appxbundle FluentTerminal.App.appxbundle
 - cmd: pushd FluentTerminal.App\AppPackages\FluentTerminal*\ && dir && xcopy "*.cer" "../../../MsiInstaller/" /e/i/f && popd && ren MsiInstaller\*.cer FluentTerminal.App.cer
-- cmd: pushd MsiInstaller && powershell.exe -ExecutionPolicy Bypass  -file ".\Generate-AppxMsi.ps1" && popd
+- cmd: pushd MsiInstaller && powershell.exe -ExecutionPolicy Bypass  -file ".\Generate-AppxMsi.ps1" && ren FluentTerminalInstaller.msi %MSI_ARTIFACT_NAME% && popd
 artifacts:
-  - path: 'FluentTerminal-v%APPVEYOR_BUILD_VERSION%-${GIT_COMMIT_SHORT}.zip'
+  - path: '%APPX_ARTIFACT_NAME%'
     name: AppPackage
-  - path: 'MsiInstaller/FluentTerminalInstaller.msi'
+  - path: 'MsiInstaller/%MSI_ARTIFACT_NAME%'
     name: MsiInstaller
 build_script:
   - msbuild /maxcpucount:%NUMBER_OF_PROCESSORS% /t:Build /p:Configuration=Release /p:AppxBundle=Always /p:Platform="x64" /v:q /nologo FluentTerminal.sln
 test_script:
   - dotnet test ./FluentTerminal.App.Services.Test
 deploy:
-  release: 'FluentTerminal-%APPVEYOR_BUILD_VERSION%-${GIT_COMMIT_SHORT}'
+  release: '%APP_BUILD_VERSION%'
   description: 'Build ${APPVEYOR_REPO_COMMIT} on master branch'
   provider: GitHub
   auth_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ platform:
 - x64
 skip_tags: true
 before_build:
-- cmd: set APP_BUILD_VERSION=%APPVEYOR_BUILD_VERSION%.0
+- cmd: set APP_BUILD_VERSION=1.1.%APPVEYOR_BUILD_NUMBER%.0
 - cmd: git rev-parse --short HEAD>commit.txt && set /p GIT_COMMIT_SHORT=<commit.txt
 - cmd: set MSI_ARTIFACT_NAME=FluentTerminalInstaller-v%APP_BUILD_VERSION%-%GIT_COMMIT_SHORT%.msi
 - cmd: set APPX_ARTIFACT_NAME=FluentTerminal-v%APP_BUILD_VERSION%-%GIT_COMMIT_SHORT%.zip


### PR DESCRIPTION
- Enable version upgrade for msi installer during installation (previous version of installer is uninstalled automatically)
- Appveyor build version changed to 3 digits common format; Second digit of build number is increased to avoid strange internal Appveyor bug with fetching wrong state of project sources.
- FluentTerminal version tagging rolled back to 4 digits format
- msi installer named to contain version number