### PR TITLE
Automatically download and run updates

### DIFF
--- a/FluentTerminal.App.Services/ApplicationDataContainers.cs
+++ b/FluentTerminal.App.Services/ApplicationDataContainers.cs
@@ -7,5 +7,6 @@
         public IApplicationDataContainer Themes { get; set; }
         public IApplicationDataContainer KeyBindings { get; set; }
         public IApplicationDataContainer ShellProfiles { get; set; }
+        public IApplicationDataContainer AutoUpdate { get; set; }
     }
 }

--- a/FluentTerminal.App.Services/Constants.cs
+++ b/FluentTerminal.App.Services/Constants.cs
@@ -6,5 +6,6 @@
         public const string KeyBindingsContainerName = "KeyBindings";
         public const string ShellProfilesContainerName = "ShellProfiles";
         public const string AutoUpdateContainerName = "AutoUpdate";
+        public const int CheckForUpdateHoursInterval = 24;
     }
 }

--- a/FluentTerminal.App.Services/Constants.cs
+++ b/FluentTerminal.App.Services/Constants.cs
@@ -5,5 +5,6 @@
         public const string ThemesContainerName = "Themes";
         public const string KeyBindingsContainerName = "KeyBindings";
         public const string ShellProfilesContainerName = "ShellProfiles";
+        public const string AutoUpdateContainerName = "AutoUpdate";
     }
 }

--- a/FluentTerminal.App.Services/ISettingsService.cs
+++ b/FluentTerminal.App.Services/ISettingsService.cs
@@ -40,6 +40,6 @@ namespace FluentTerminal.App.Services
         string ExportSettings();
         void ImportSettings(string serializedSettings);
         void SaveAutoUpdateData(string version, string path);
-        IDictionary<string, string> GetAutoUpdateData();
+        ApplicationVersionUpgradeData GetAutoUpdateData();
     }
 }

--- a/FluentTerminal.App.Services/ISettingsService.cs
+++ b/FluentTerminal.App.Services/ISettingsService.cs
@@ -39,5 +39,7 @@ namespace FluentTerminal.App.Services
         ShellProfile GetShellProfile(Guid id);
         string ExportSettings();
         void ImportSettings(string serializedSettings);
+        void SaveAutoUpdateData(string version, string path);
+        IDictionary<string, string> GetAutoUpdateData();
     }
 }

--- a/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
@@ -31,6 +31,6 @@ namespace FluentTerminal.App.Services
 
         Task SaveTextFileAsync(string path, string content);
 
-        void StartApplicationUpdate(string url);
+        void RunMSI(string url);
     }
 }

--- a/FluentTerminal.App.Services/IUpdateService.cs
+++ b/FluentTerminal.App.Services/IUpdateService.cs
@@ -5,7 +5,7 @@ namespace FluentTerminal.App.Services
 {
     public interface IUpdateService
     {
-        Task CheckForUpdate(bool notifyNoUpdate = false);
+        Task CheckForUpdate(bool runUpdate = false);
         Version GetCurrentVersion();
         Task<Version> GetLatestVersionAsync();
     }

--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -24,6 +24,7 @@ namespace FluentTerminal.App.Services.Implementation
                 MouseRightClickAction = MouseAction.ContextMenu,
                 AlwaysShowTabs = false,
                 ShowNewOutputIndicator = false,
+                AutoInstallUpdates = true,
                 EnableTrayIcon = true,
                 ShowCustomTitleInTitlebar = true
             };

--- a/FluentTerminal.App.Services/Implementation/SettingsService.cs
+++ b/FluentTerminal.App.Services/Implementation/SettingsService.cs
@@ -19,6 +19,7 @@ namespace FluentTerminal.App.Services.Implementation
         private readonly IApplicationDataContainer _roamingSettings;
         private readonly IApplicationDataContainer _shellProfiles;
         private readonly IApplicationDataContainer _themes;
+        private readonly IApplicationDataContainer _autoUpdate;
 
         public SettingsService(IDefaultValueProvider defaultValueProvider, ApplicationDataContainers containers)
         {
@@ -29,6 +30,7 @@ namespace FluentTerminal.App.Services.Implementation
             _themes = containers.Themes;
             _keyBindings = containers.KeyBindings;
             _shellProfiles = containers.ShellProfiles;
+            _autoUpdate = containers.AutoUpdate;
 
             foreach (var theme in _defaultValueProvider.GetPreInstalledThemes())
             {
@@ -323,6 +325,34 @@ namespace FluentTerminal.App.Services.Implementation
             {
                 ThemeAdded?.Invoke(this, theme);
             }
+        }
+
+        public void SaveAutoUpdateData(string version, string path)
+        {
+            _autoUpdate.SetValue("version", version);
+            _autoUpdate.SetValue("path", path);
+
+            _autoUpdate.TryGetValue("version", out object savedVersion);
+            string test = (string)savedVersion;
+        }
+
+        public IDictionary<string, string> GetAutoUpdateData()
+        {
+            var autoUpdateData = new Dictionary<string, string>();
+
+            try
+            {
+                autoUpdateData.Add("version", _autoUpdate.TryGetValue("version", out object version) && !String.IsNullOrEmpty((string)version) ? (string)version : "0.0.0.0");
+                _autoUpdate.TryGetValue("version", out object savedVersion);
+                string test = (string)savedVersion;
+                autoUpdateData.Add("path", _autoUpdate.TryGetValue("path", out object path) && !String.IsNullOrEmpty((string)path) ? (string)path : String.Empty);
+            }
+            catch(Exception ex)
+            {
+
+            }
+
+            return autoUpdateData;
         }
     }
 }

--- a/FluentTerminal.App.Services/Implementation/SettingsService.cs
+++ b/FluentTerminal.App.Services/Implementation/SettingsService.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 
 namespace FluentTerminal.App.Services.Implementation
@@ -12,6 +13,11 @@ namespace FluentTerminal.App.Services.Implementation
     {
         public const string CurrentThemeKey = "CurrentTheme";
         public const string DefaultShellProfileKey = "DefaultShellProfile";
+
+        private const string AutoUpdateVersionKey = "Version";
+        private const string AutoUpdatePathKey = "Path";
+
+        private const string AutoUpdateDefaultVersion = "0.0.0.0";
 
         private readonly IDefaultValueProvider _defaultValueProvider;
         private readonly IApplicationDataContainer _keyBindings;
@@ -327,21 +333,31 @@ namespace FluentTerminal.App.Services.Implementation
             }
         }
 
+        private void ValidateAutoUpdateData()
+        {
+            if (_autoUpdate.TryGetValue("path", out object path) && !String.IsNullOrEmpty((string)path))
+            {
+                if (!System.IO.File.Exists((string)path))
+                {
+                    _autoUpdate.SetValue(AutoUpdateVersionKey, AutoUpdateDefaultVersion);
+                    _autoUpdate.SetValue(AutoUpdatePathKey, string.Empty);
+                }
+            }
+        }
+
         public void SaveAutoUpdateData(string version, string path)
         {
-            _autoUpdate.SetValue("version", version);
-            _autoUpdate.SetValue("path", path);
-
-            _autoUpdate.TryGetValue("version", out object savedVersion);
-            string test = (string)savedVersion;
+            _autoUpdate.SetValue(AutoUpdateVersionKey, version);
+            _autoUpdate.SetValue(AutoUpdatePathKey, path);
         }
 
         public ApplicationVersionUpgradeData GetAutoUpdateData()
         {
+            ValidateAutoUpdateData();
             return new ApplicationVersionUpgradeData
             {
-                Version = new Version(_autoUpdate.TryGetValue("version", out object version) && !String.IsNullOrEmpty((string)version) ? (string)version : "0.0.0.0"),
-                Path = _autoUpdate.TryGetValue("path", out object path) && !String.IsNullOrEmpty((string)path) ? (string)path : String.Empty
+                Version = new Version(_autoUpdate.TryGetValue(AutoUpdateVersionKey, out object version) && !String.IsNullOrEmpty((string)version) ? (string)version : AutoUpdateDefaultVersion),
+                Path = _autoUpdate.TryGetValue(AutoUpdatePathKey, out object path) && !String.IsNullOrEmpty((string)path) ? (string)path : String.Empty
             };
         }
     }

--- a/FluentTerminal.App.Services/Implementation/SettingsService.cs
+++ b/FluentTerminal.App.Services/Implementation/SettingsService.cs
@@ -336,23 +336,13 @@ namespace FluentTerminal.App.Services.Implementation
             string test = (string)savedVersion;
         }
 
-        public IDictionary<string, string> GetAutoUpdateData()
+        public ApplicationVersionUpgradeData GetAutoUpdateData()
         {
-            var autoUpdateData = new Dictionary<string, string>();
-
-            try
+            return new ApplicationVersionUpgradeData
             {
-                autoUpdateData.Add("version", _autoUpdate.TryGetValue("version", out object version) && !String.IsNullOrEmpty((string)version) ? (string)version : "0.0.0.0");
-                _autoUpdate.TryGetValue("version", out object savedVersion);
-                string test = (string)savedVersion;
-                autoUpdateData.Add("path", _autoUpdate.TryGetValue("path", out object path) && !String.IsNullOrEmpty((string)path) ? (string)path : String.Empty);
-            }
-            catch(Exception ex)
-            {
-
-            }
-
-            return autoUpdateData;
+                Version = new Version(_autoUpdate.TryGetValue("version", out object version) && !String.IsNullOrEmpty((string)version) ? (string)version : "0.0.0.0"),
+                Path = _autoUpdate.TryGetValue("path", out object path) && !String.IsNullOrEmpty((string)path) ? (string)path : String.Empty
+            };
         }
     }
 }

--- a/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
@@ -88,9 +88,9 @@ namespace FluentTerminal.App.Services.Implementation
             }
         }
 
-        public void StartApplicationUpdate(string url)
+        public void RunMSI(string path)
         {
-            _appServiceConnection.SendMessageAsync(CreateMessage(new ApplicationUpdateRequest { Url = url }));
+            _appServiceConnection.SendMessageAsync(CreateMessage(new MSIRunRequest { Path = path }));
         }
 
         public async Task<CreateTerminalResponse> CreateTerminal(int id, TerminalSize size, ShellProfile shellProfile, SessionType sessionType)

--- a/FluentTerminal.App.Services/Implementation/UpdateService.cs
+++ b/FluentTerminal.App.Services/Implementation/UpdateService.cs
@@ -5,12 +5,8 @@ using RestSharp;
 using System.Threading.Tasks;
 using System.Collections;
 using System.Linq;
-using Windows.Networking.BackgroundTransfer;
-using Windows.Storage;
 using System.Net;
 using System.IO;
-using System.Collections.Generic;
-using System.Diagnostics;
 using FluentTerminal.Models;
 
 namespace FluentTerminal.App.Services.Implementation

--- a/FluentTerminal.App.Services/Implementation/UpdateService.cs
+++ b/FluentTerminal.App.Services/Implementation/UpdateService.cs
@@ -11,6 +11,7 @@ using System.Net;
 using System.IO;
 using System.Collections.Generic;
 using System.Diagnostics;
+using FluentTerminal.Models;
 
 namespace FluentTerminal.App.Services.Implementation
 {
@@ -73,9 +74,8 @@ namespace FluentTerminal.App.Services.Implementation
         {
             try
             {
-                IDictionary<string, string> updateData = _settingsService.GetAutoUpdateData();
-                string versionStr = updateData["version"];
-                Version downloaded = new Version(versionStr);
+                ApplicationVersionUpgradeData updateData = _settingsService.GetAutoUpdateData();
+                Version downloaded = updateData.Version;
                 Version current = new Version("0.0.0.0"); // GetCurrentVersion();
                 Version latest = await GetLatestVersionAsync();
 
@@ -83,7 +83,7 @@ namespace FluentTerminal.App.Services.Implementation
                 {
                     _notificationService.ShowNotification("Update will be installed", "Installation of new application version is started.");
 
-                    _trayProcessCommunicationService.StartApplicationUpdate(updateData["path"]);
+                    _trayProcessCommunicationService.RunMSI(updateData.Path);
                 }
                 else if (latest > current)
                 {

--- a/FluentTerminal.App.Services/Implementation/UpdateService.cs
+++ b/FluentTerminal.App.Services/Implementation/UpdateService.cs
@@ -70,6 +70,7 @@ namespace FluentTerminal.App.Services.Implementation
             }
             catch (Exception)
             {
+                _notificationService.ShowNotification("Download failed", $"Download failed for installer of version {version}.");
                 Logger.Instance.Error($"Download error for version {version} {url}");
                 return string.Empty;
             }
@@ -110,7 +111,7 @@ namespace FluentTerminal.App.Services.Implementation
                         if (result == DialogButton.OK)
                         {
                             string installerFilePath = await DownloadInstaller(latest.ToString(4), installerFileUrl);
-                            if (runUpdate && string.IsNullOrEmpty(installerFilePath))
+                            if (runUpdate && !string.IsNullOrEmpty(installerFilePath))
                             {
                                 runInstaller(latest.ToString(4), installerFilePath);
                             }

--- a/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
@@ -20,7 +20,7 @@ namespace FluentTerminal.App.ViewModels.Settings
             _updateService = updateService;
             _applicationView = applicationView;
 
-            CheckForUpdatesCommand = new AsyncCommand(() => CheckForUpdate(true));
+            CheckForUpdatesCommand = new AsyncCommand(() => CheckForUpdate(false));
         }
 
         public IAsyncCommand CheckForUpdatesCommand { get; }

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -130,6 +130,20 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        public bool AutoInstallUpdates
+        {
+            get => _applicationSettings.AutoInstallUpdates;
+            set
+            {
+                if (_applicationSettings.AutoInstallUpdates != value)
+                {
+                    _applicationSettings.AutoInstallUpdates = value;
+                    _settingsService.SaveApplicationSettings(_applicationSettings);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         public bool BottomIsSelected
         {
             get => TabsPosition == TabsPosition.Bottom;
@@ -304,6 +318,7 @@ namespace FluentTerminal.App.ViewModels.Settings
                 NewTerminalLocation = defaults.NewTerminalLocation;
                 AlwaysShowTabs = defaults.AlwaysShowTabs;
                 ShowNewOutputIndicator = defaults.ShowNewOutputIndicator;
+                AutoInstallUpdates = defaults.AutoInstallUpdates;
                 EnableTrayIcon = defaults.EnableTrayIcon;
                 ShowCustomTitleInTitlebar = defaults.ShowCustomTitleInTitlebar;
             }

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -45,6 +45,7 @@ namespace FluentTerminal.App
         private readonly ITrayProcessCommunicationService _trayProcessCommunicationService;
         private readonly ISshHelperService _sshHelperService;
         private readonly IDialogService _dialogService;
+        private readonly IUpdateService _updateService;
         private bool _alreadyLaunched;
         private ApplicationSettings _applicationSettings;
         private readonly IContainer _container;
@@ -70,7 +71,8 @@ namespace FluentTerminal.App
                 RoamingSettings = new ApplicationDataContainerAdapter(ApplicationData.Current.RoamingSettings),
                 KeyBindings = new ApplicationDataContainerAdapter(ApplicationData.Current.RoamingSettings.CreateContainer(Constants.KeyBindingsContainerName, ApplicationDataCreateDisposition.Always)),
                 ShellProfiles = new ApplicationDataContainerAdapter(ApplicationData.Current.LocalSettings.CreateContainer(Constants.ShellProfilesContainerName, ApplicationDataCreateDisposition.Always)),
-                Themes = new ApplicationDataContainerAdapter(ApplicationData.Current.RoamingSettings.CreateContainer(Constants.ThemesContainerName, ApplicationDataCreateDisposition.Always))
+                Themes = new ApplicationDataContainerAdapter(ApplicationData.Current.RoamingSettings.CreateContainer(Constants.ThemesContainerName, ApplicationDataCreateDisposition.Always)),
+                AutoUpdate = new ApplicationDataContainerAdapter(ApplicationData.Current.RoamingSettings.CreateContainer(Constants.AutoUpdateContainerName, ApplicationDataCreateDisposition.Always))
             };
             var builder = new ContainerBuilder();
             builder.RegisterType<SettingsService>().As<ISettingsService>().SingleInstance();
@@ -108,6 +110,8 @@ namespace FluentTerminal.App
             _trayProcessCommunicationService = _container.Resolve<ITrayProcessCommunicationService>();
 
             _sshHelperService = _container.Resolve<ISshHelperService>();
+
+            _updateService = _container.Resolve<IUpdateService>();
 
             _dialogService = _container.Resolve<IDialogService>();
 
@@ -349,6 +353,8 @@ namespace FluentTerminal.App
                 }
                 await CreateMainView(typeof(MainPage), viewModel, true).ConfigureAwait(true);
                 Window.Current.Activate();
+
+                _updateService.CheckForUpdate();
             }
             else if (_mainViewModels.Count == 0)
             {

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -354,7 +354,7 @@ namespace FluentTerminal.App
                 await CreateMainView(typeof(MainPage), viewModel, true).ConfigureAwait(true);
                 Window.Current.Activate();
 
-                _updateService.CheckForUpdate();
+                _updateService.CheckForUpdate(true);
             }
             else if (_mainViewModels.Count == 0)
             {

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -160,6 +160,12 @@
                     Margin="{StaticResource ItemMargin}"
                     Header="Show new output indicator on background tabs"
                     IsOn="{x:Bind ViewModel.ShowNewOutputIndicator, Mode=TwoWay}" />
+
+                <ToggleSwitch
+                    x:Uid="AutoInstallUpdates"
+                    Margin="{StaticResource ItemMargin}"
+                    Header="Automatically download and install updates on next launch of application"
+                    IsOn="{x:Bind ViewModel.AutoInstallUpdates, Mode=TwoWay}" />
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/FluentTerminal.Models/ApplicationSettings.cs
+++ b/FluentTerminal.Models/ApplicationSettings.cs
@@ -15,6 +15,7 @@ namespace FluentTerminal.Models
         public MouseAction MouseRightClickAction { get; set; }
         public bool AlwaysShowTabs { get; set; }
         public bool ShowNewOutputIndicator { get; set; }
+        public bool AutoInstallUpdates { get; set; }
         public bool EnableTrayIcon { get; set; }
         public bool ShowCustomTitleInTitlebar { get; set; }
     }

--- a/FluentTerminal.Models/ApplicationVersionUpgradeData.cs
+++ b/FluentTerminal.Models/ApplicationVersionUpgradeData.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FluentTerminal.Models
+{
+    public class ApplicationVersionUpgradeData
+    {
+        public Version Version { get; set; }
+        public string Path { get; set; }
+    }
+}

--- a/FluentTerminal.Models/Requests/ApplicationUpdateRequest.cs
+++ b/FluentTerminal.Models/Requests/ApplicationUpdateRequest.cs
@@ -1,7 +1,0 @@
-﻿namespace FluentTerminal.Models.Requests
-{
-    public class ApplicationUpdateRequest
-    {
-        public string Url { get; set; }
-    }
-}

--- a/FluentTerminal.Models/Requests/MSIRunRequest.cs
+++ b/FluentTerminal.Models/Requests/MSIRunRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace FluentTerminal.Models.Requests
+{
+    public class MSIRunRequest
+    {
+        public string Path { get; set; }
+    }
+}

--- a/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
+++ b/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
@@ -158,10 +158,10 @@ namespace FluentTerminal.SystemTray.Services
 
                 deferral.Complete();
             }
-            else if (messageType == nameof(ApplicationUpdateRequest))
+            else if (messageType == nameof(MSIRunRequest))
             {
-                ApplicationUpdateRequest request = JsonConvert.DeserializeObject<ApplicationUpdateRequest>(messageContent);
-                Utilities.RunApplicationUpdate(request.Url);
+                MSIRunRequest request = JsonConvert.DeserializeObject<MSIRunRequest>(messageContent);
+                Utilities.RunMSI(request.Path);
             }
         }
 

--- a/FluentTerminal.SystemTray/Utilities.cs
+++ b/FluentTerminal.SystemTray/Utilities.cs
@@ -569,11 +569,11 @@ namespace FluentTerminal.SystemTray
             WebClient client = new WebClient();
             try
             {
-                string fileName = Path.GetTempPath() + Guid.NewGuid().ToString() + ".msi";
-                client.DownloadFile(url, fileName);
+                //string fileName = Path.GetTempPath() + Guid.NewGuid().ToString() + ".msi";
+                //client.DownloadFile(url, fileName);
                 Process process = new Process();
                 process.StartInfo.FileName = "msiexec.exe";
-                process.StartInfo.Arguments = $"/i \"{fileName}\"";
+                process.StartInfo.Arguments = $"/i \"{url}\"";
                 process.Start();
             }
             catch (Exception) { }

--- a/FluentTerminal.SystemTray/Utilities.cs
+++ b/FluentTerminal.SystemTray/Utilities.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.NetworkInformation;
 using System.Reflection;
 using System.Windows.Input;
@@ -561,19 +560,16 @@ namespace FluentTerminal.SystemTray
             }
         }
 
-        internal static void RunApplicationUpdate(string url)
+        internal static void RunMSI(string msiPath)
         {
-            if (string.IsNullOrEmpty(url))
+            if (string.IsNullOrEmpty(msiPath))
                 return;
 
-            WebClient client = new WebClient();
             try
             {
-                //string fileName = Path.GetTempPath() + Guid.NewGuid().ToString() + ".msi";
-                //client.DownloadFile(url, fileName);
                 Process process = new Process();
                 process.StartInfo.FileName = "msiexec.exe";
-                process.StartInfo.Arguments = $"/i \"{url}\"";
+                process.StartInfo.Arguments = $"/i \"{msiPath}\"";
                 process.Start();
             }
             catch (Exception) { }


### PR DESCRIPTION
Fixes #83 

- "Automatically download and install updates on next launch of application" settings option is added
- Downloaded installer version and file path are saved in application settings storage
- New update msi file is downloaded on .NET Standard side; msiexec process launch happens from tray process side (UWP can't launch msiexec successfully, probably, lack of access rights)
- Application notifies about start of new update download, download completed, installation started.
- Checks to download new update every 24 hours (installs on next launch)