### PR TITLE
Repair Auto Install Updates Settings option.

### DIFF
--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -126,6 +126,20 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        public bool AutoInstallUpdates
+        {
+            get => _applicationSettings.AutoInstallUpdates;
+            set
+            {
+                if (_applicationSettings.AutoInstallUpdates != value)
+                {
+                    _applicationSettings.AutoInstallUpdates = value;
+                    _settingsService.SaveApplicationSettings(_applicationSettings);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         public bool UseMoshByDefault
         {
             get => _applicationSettings.UseMoshByDefault;
@@ -344,6 +358,7 @@ namespace FluentTerminal.App.ViewModels.Settings
                 NewTerminalLocation = defaults.NewTerminalLocation;
                 AlwaysShowTabs = defaults.AlwaysShowTabs;
                 ShowNewOutputIndicator = defaults.ShowNewOutputIndicator;
+                AutoInstallUpdates = defaults.AutoInstallUpdates;
                 EnableTrayIcon = defaults.EnableTrayIcon;
                 ShowCustomTitleInTitlebar = defaults.ShowCustomTitleInTitlebar;
                 UseMoshByDefault = defaults.UseMoshByDefault;

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -162,6 +162,12 @@
                     IsOn="{x:Bind ViewModel.ShowNewOutputIndicator, Mode=TwoWay}" />
 
                 <ToggleSwitch
+                    x:Uid="AutoInstallUpdates"
+                    Margin="{StaticResource ItemMargin}"
+                    Header="Automatically download and install updates on next launch of application"
+                    IsOn="{x:Bind ViewModel.AutoInstallUpdates, Mode=TwoWay}" />
+
+                <ToggleSwitch
                     x:Uid="UseMoshByDefault"
                     Margin="{StaticResource ItemMargin}"
                     Header="Default to Mosh for SSH connections"


### PR DESCRIPTION
Auto Install updates Settings page option appears to be broken by latest merges and is not displayed at all.

cc: @peske 