### PR TITLE
Changed FluentTerminal.App_TemporaryKey.pfx thumbprint.

### DIFF
--- a/FluentTerminal.App/FluentTerminal.App.csproj
+++ b/FluentTerminal.App/FluentTerminal.App.csproj
@@ -18,7 +18,7 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <PackageCertificateKeyFile>FluentTerminal.App_TemporaryKey.pfx</PackageCertificateKeyFile>
-    <PackageCertificateThumbprint>F96F3E0E485F07E8E98DA6E5C06AA4B6F112B498</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>CB8FD097F5D8E7DD8626F7DD69C6DD15F92A460F</PackageCertificateThumbprint>
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <AppxBundle>Always</AppxBundle>
     <AppxBundlePlatforms>x86|x64</AppxBundlePlatforms>


### PR DESCRIPTION
For some reason the old certificate thumbprint (`F96F3E0E485F07E8E98DA6E5C06AA4B6F112B498`) doesn't work for me anymore. When I try to build our `master`, I'm getting:

```
Error		Certificate does not match supplied signing thumbprint: F96F3E0E485F07E8E98DA6E5C06AA4B6F112B498	FluentTerminal.App
```

I've used the following PowerShell to determine the actual thumbprint:

```
Get-PfxCertificate -FilePath .\FluentTerminal.App_TemporaryKey.pfx

Thumbprint                                Subject
----------                                -------
CB8FD097F5D8E7DD8626F7DD69C6DD15F92A460F  CN=BDC72197-B634-438A-B863-16DCB7D90C85
```

And as you can see, it looks that the thumbprint is actually `CB8FD097F5D8E7DD8626F7DD69C6DD15F92A460F`. I don't have a clue how it may happened. Did someone changed the cert without changing the thumbprint?

Anyway, I'm creating this PR to see what AppVeyor will say about that (will it be able to build).

Please don't merge!